### PR TITLE
Add GitHub action for GPU training

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -1,0 +1,32 @@
+name: Train Agent
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.py'
+      - '.github/workflows/train.yml'
+
+jobs:
+  train:
+    # Requires a GPU self-hosted runner for maximum performance
+    runs-on: [self-hosted, gpu]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Start training
+        env:
+          CUDA_VISIBLE_DEVICES: '0'
+        run: |
+          python src/env.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # pycoplayer
 Pycoplayer is a general AI that learns how to play games through trial and error, based on the visual and auditory output from any game of your choosing, it delivers keyboard, mouse, and controller input to play.
+
+## Training via GitHub Actions
+A workflow file located at `.github/workflows/train.yml` can be used to train the agent automatically. The job expects a **self‑hosted GPU runner** to maximise training performance. Trigger the workflow manually or whenever Python files change.
+
+## Suggested optimizations
+- Run training on a GPU enabled runner for faster neural network inference.
+- Periodically save and load model checkpoints to resume interrupted runs.
+- Experiment with techniques like prioritized experience replay or double DQN to improve learning stability.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Basic dependencies for training
+numpy
+matplotlib
+ipython
+mss
+pillow
+opencv-python
+# Gymnasium with Box2D environment for CarRacing
+"gymnasium[box2d]"
+torch


### PR DESCRIPTION
## Summary
- add workflow to train the model on a self-hosted GPU runner
- document training workflow and suggestions in README
- add requirements file for dependencies

## Testing
- `pytest -q`