### PR TITLE
Adjust training workflow for CPU runner

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -1,0 +1,30 @@
+name: Train Agent
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.py'
+      - '.github/workflows/train.yml'
+
+jobs:
+  train:
+    # Runs on a standard GitHub Actions runner (CPU only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Start training
+        run: |
+          python src/env.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # pycoplayer
 Pycoplayer is a general AI that learns how to play games through trial and error, based on the visual and auditory output from any game of your choosing, it delivers keyboard, mouse, and controller input to play.
+
+## Training via GitHub Actions
+A workflow at `.github/workflows/train.yml` runs training on a standard GitHub Actions runner using only the CPU. Trigger the workflow manually or whenever Python files change. For faster learning you may configure your own GPU runner.
+
+## Suggested optimizations
+- Run training on a GPU enabled runner for faster neural network inference.
+- Periodically save and load model checkpoints to resume interrupted runs.
+- Experiment with techniques like prioritized experience replay or double DQN to improve learning stability.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Basic dependencies for training
+numpy
+matplotlib
+ipython
+mss
+pillow
+opencv-python
+# Gymnasium with Box2D environment for CarRacing
+"gymnasium[box2d]"
+torch


### PR DESCRIPTION
## Summary
- run the training workflow on `ubuntu-latest` instead of a self-hosted GPU
- remove CUDA environment variable from workflow
- update README to document CPU-based training

## Testing
- `pytest -q`
